### PR TITLE
Adding support for Netbox 3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0 (2023-04-28)
+
+* Fixed support for Netbox 3.5. NOTE: Plugin version 0.3.0+ is only compatible with Netbox 3.5+
+
 ## 0.2.2 (2023-01-18)
 
 * Fix API Filtersets

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The plugin does not directly provide an automated approach to ingesting provider
 This plugin is only supported on NetBox 3.4 or higher, for exact compatibility information, see the table below.  
 | NetBox Version | Plugin Version |
 |--|--|
+| 3.5 | 0.3.0 |
 | 3.4 | 0.2.2 |
 
 

--- a/netbox_circuitmaintenance/__init__.py
+++ b/netbox_circuitmaintenance/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Jason Yates"""
 __email__ = 'me@jasonyates.co.uk'
-__version__ = '0.2.2'
+__version__ = '0.3.0'
 
 
 from extras.plugins import PluginConfig

--- a/netbox_circuitmaintenance/forms.py
+++ b/netbox_circuitmaintenance/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from netbox.forms import NetBoxModelForm, NetBoxModelFilterSetForm
-from utilities.forms import DateTimePicker, DynamicModelChoiceField
+from utilities.forms.fields import DynamicModelChoiceField
+from utilities.forms.widgets import DateTimePicker
 from circuits.models import Provider, Circuit
 from .models import CircuitMaintenance, CircuitMaintenanceImpact, CircuitMaintenanceNotifications, CircuitMaintenanceTypeChoices, CircuitMaintenanceImpactTypeChoices
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-circuitmaintenance"
-version = "0.2.2"
+version = "0.3.0"
 description = "Provides the ability to record circuit maintenance, maintenance impact and maintenance notifications in Netbox and link them to Providers and Circuits."
 readme = "README.md"
 authors = [{ name = "Jason Yates", email = "me@jasonyates.co.uk" }]
@@ -19,7 +19,7 @@ Homepage = "https://github.com/jasonyates/netbox-circuitmaintenance"
 dev = ["black", "bumpver", "isort", "pip-tools", "pytest"]
 
 [tool.bumpver]
-current_version = "0.2.2"
+current_version = "0.3.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ python =
     3.8: py38, format, lint, build
 
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.3.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
     packages=find_packages(include=['netbox_circuitmaintenance', 'netbox_circuitmaintenance.*']),
     test_suite='tests',
     url='https://github.com/jasonyates/netbox-circuitmaintenance',
-    version='0.2.2',
+    version='0.3.0',
     zip_safe=False,
 )


### PR DESCRIPTION
Fixes #17

Note: Version 0.3.0 of this plugin is only compatible with Netbox 3.5+, for Netbox 3.4.x please use version 0.2.2