### PR TITLE
Bugfix duplication of names in url file

### DIFF
--- a/netbox_circuitmaintenance/urls.py
+++ b/netbox_circuitmaintenance/urls.py
@@ -26,7 +26,7 @@ urlpatterns = (
     path('circuitmaintenance/<int:pk>/changelog/', ObjectChangeLogView.as_view(), name='circuitmaintenance_changelog', kwargs={
         'model': models.CircuitMaintenance
     }),
-    path('circuitimpact/<int:pk>/changelog/', ObjectChangeLogView.as_view(), name='circuitmaintenance_changelog', kwargs={
+    path('circuitimpact/<int:pk>/changelog/', ObjectChangeLogView.as_view(), name='circuitimpact_changelog', kwargs={
         'model': models.CircuitMaintenanceImpact
     }),
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,14 @@ dev = [
     "isort==6.0.1",
     "pip-tools",
     "pytest",
-    "flake8==7.2.0",
+    "tox",
+    "flake8==7.0.0",
     "pyproject-flake8==7.0.0",
     "twine==6.1.0",
-    "Sphinx==8.2.3",
+    "Sphinx==7.2.6",
     "watchdog==6.0.0",
 ]
+
 
 [project.urls]
 Homepage = "https://github.com/jasonyates/netbox-circuitmaintenance"


### PR DESCRIPTION
Hi, I was fixed issue with urls.name duplication:

> Server Error
> There was a problem with your request. Please contact an administrator.
> 
> The complete exception is provided below:
> 
> <class 'django.template.exceptions.TemplateDoesNotExist'>
> 
> netbox_circuitmaintenance/circuitmaintenanceimpact.html
> 
> Python version: 3.12.0
> NetBox version: 4.2.2
> Plugins: 
>   netbox_circuitmaintenance: 0.5.0
>   netbox_plugin_mclag: 0.2.0
> If further assistance is required, please post to the [NetBox discussion forum](https://github.com/netbox-community/netbox/discussions) on GitHub.

Poetry testing

> Writing lock file
> 
> Installing the current project: netbox-circuitmaintenance (0.5.0)
> ╭- ~/Documents/ravenrs-netbox-circuitmaintenance                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      ok | took 12s | at 17:55:10 -╮
> ╰- on bugfix-dupli.._in_url_file ?3 | ⭐ 3.12.8 venv312  ppoetry run tox                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          -╯
> .pkg: install_requires> python -I -m pip install setuptools
> .pkg: _optional_hooks> python /Users/p_voronov/Documents/ravenrs-netbox-circuitmaintenance/venv312/lib/python3.12/site-packages/pyproject_api/_backend.py True setuptools.build_meta
> .pkg: get_requires_for_build_sdist> python /Users/p_voronov/Documents/ravenrs-netbox-circuitmaintenance/venv312/lib/python3.12/site-packages/pyproject_api/_backend.py True setuptools.build_meta
> .pkg: build_sdist> python /Users/p_voronov/Documents/ravenrs-netbox-circuitmaintenance/venv312/lib/python3.12/site-packages/pyproject_api/_backend.py True setuptools.build_meta
> py: install_package> python -I -m pip install --force-reinstall --no-deps /Users/p_voronov/Documents/ravenrs-netbox-circuitmaintenance/.tox/.tmp/package/1/netbox_circuitmaintenance-0.5.0.tar.gz
>   py: OK (6.89 seconds)
>   congratulations :) (7.05 seconds)

I've already test in my netbox-4.2.2 test enviroment and it works.
![image](https://github.com/user-attachments/assets/0456f6c1-9eb0-42b8-998c-13bfce1f108f)
