### PR TITLE
buf fix of qs there is no file "site" in CircuitTermination it's "_si…

### DIFF
--- a/netbox_circuitmaintenance/template_content.py
+++ b/netbox_circuitmaintenance/template_content.py
@@ -26,7 +26,7 @@ class SiteMaintenanceList(PluginTemplateExtension):
     def left_page(self):
 
         return self.render('netbox_circuitmaintenance/providermaintenance_include.html', extra_context={
-            'circuitmaintenance': CircuitMaintenanceImpact.objects.filter(Q(circuit__termination_a__site=self.context['object']) | Q(circuit__termination_z__site=self.context['object']), circuitmaintenance__status__in=['TENTATIVE', 'CONFIRMED', 'IN-PROCESS', 'RE-SCHEDULED', 'UNKNOWN']),
+            'circuitmaintenance': CircuitMaintenanceImpact.objects.filter(Q(circuit__termination_a___site=self.context['object']) | Q(circuit__termination_z___site=self.context['object']), circuitmaintenance__status__in=['TENTATIVE', 'CONFIRMED', 'IN-PROCESS', 'RE-SCHEDULED', 'UNKNOWN']),
         })
 
 


### PR DESCRIPTION
buf fix of qs there is no file "site" in CircuitTermination it's "_site". so it was a cause of Server error while rendering site detailed view:
ValueError: Cannot query "test_site": Must be "CircuitTermination" instance:

>   File "/opt/netbox-4.2.2/venv/lib/python3.12/site-packages/netbox_circuitmaintenance/template_content.py", line 29, in left_page
>     'circuitmaintenance': CircuitMaintenanceImpact.objects.filter(Q(circuit__termination_a__site=self.context['object']) | Q(circuit__termination_z__site=self.context['object']), circuitmaintenance__status__in=['TENTATIVE', 'CONFIRMED', 'IN-PROCESS', 'RE-SCHEDULED', 'UNKNOWN']),
>                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/opt/netbox-4.2.2/venv/lib/python3.12/site-packages/django/db/models/manager.py", line 87, in manager_method
>     return getattr(self.get_queryset(), name)(*args, **kwargs)
>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/opt/netbox-4.2.2/venv/lib/python3.12/site-packages/django/db/models/query.py", line 1476, in filter
>     return self._filter_or_exclude(False, args, kwargs)
>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/opt/netbox-4.2.2/venv/lib/python3.12/site-packages/django/db/models/query.py", line 1494, in _filter_or_exclude
>     clone._filter_or_exclude_inplace(negate, args, kwargs)
>   File "/opt/netbox-4.2.2/venv/lib/python3.12/site-packages/django/db/models/query.py", line 1501, in _filter_or_exclude_inplace
>     self._query.add_q(Q(*args, **kwargs))
>   File "/opt/netbox-4.2.2/venv/lib/python3.12/site-packages/django/db/models/sql/query.py", line 1609, in add_q
>     clause, _ = self._add_q(q_object, self.used_aliases)
>                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/opt/netbox-4.2.2/venv/lib/python3.12/site-packages/django/db/models/sql/query.py", line 1641, in _add_q
>     child_clause, needed_inner = self.build_filter(
>                                  ^^^^^^^^^^^^^^^^^^
>   File "/opt/netbox-4.2.2/venv/lib/python3.12/site-packages/django/db/models/sql/query.py", line 1468, in build_filter
>     return self._add_q(
>            ^^^^^^^^^^^^
>   File "/opt/netbox-4.2.2/venv/lib/python3.12/site-packages/django/db/models/sql/query.py", line 1641, in _add_q
>     child_clause, needed_inner = self.build_filter(
>                                  ^^^^^^^^^^^^^^^^^^
>   File "/opt/netbox-4.2.2/venv/lib/python3.12/site-packages/django/db/models/sql/query.py", line 1528, in build_filter
>     self.check_related_objects(join_info.final_field, value, join_info.opts)
>   File "/opt/netbox-4.2.2/venv/lib/python3.12/site-packages/django/db/models/sql/query.py", line 1342, in check_related_objects
>     self.check_query_object_type(value, opts, field)
>   File "/opt/netbox-4.2.2/venv/lib/python3.12/site-packages/django/db/models/sql/query.py", line 1319, in check_query_object_type
>     raise ValueError(
> ValueError: Cannot query "test_site": Must be "CircuitTermination" instance.
![image](https://github.com/user-attachments/assets/26240ff2-752a-4632-a12f-39fe9a3c3fc7)
I was tested on my dev netbox enviroment, and Netbox test enviroment.